### PR TITLE
Fix typo in Donate page text

### DIFF
--- a/src/pages/Donate/Donate.tsx
+++ b/src/pages/Donate/Donate.tsx
@@ -78,7 +78,7 @@ const Donate = () => {
 
           <p className="mb-8">
             Be part of this movement to reclaim, preserve, and share Nigeria’s
-            past. Support PtublicDomain.ng today.
+            past. Support PublicDomain.ng today.
           </p>
         </div>
         <div className="basis-1/3">


### PR DESCRIPTION
## Summary
- replace misspelled `PtublicDomain.ng` with `PublicDomain.ng` on Donate page
- scan Donate page for additional textual typos

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: Cannot find package '@eslint/js', dependency install blocked by registry access)*

------
https://chatgpt.com/codex/tasks/task_e_6896859c0b2c8320873839d7a81b2750